### PR TITLE
Add library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=ArduinoJWT
+version=1.0.1
+author=Chris Moorhouse <cm@interior-automation.co.uk>
+maintainer=Chris Moorhouse <cm@interior-automation.co.uk>
+sentence=Library for encoding and decoding JSON web tokens for the Arduino and ESP8266 platforms. 
+paragraph=This library does not currently support adding any options to the JWT and uses a fixed header for HS256.
+category=Communication
+url=https://github.com/yutter/ArduinoJWT
+architectures=avr,esp8266


### PR DESCRIPTION
A very popular way to install libraries is to use GitHub's **Clone or download > Download .ZIP file** link to download the library and then the Arduino IDE's **Sketch > Include Library > Add .ZIP Library** feature to install the downloaded file. The problem is that the Arduino IDE only [recognizes ](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#source-code)libraries that either have a header file or a library.properties file in the root library folder. Since this library stores the source files in the src it is necessary to add a library.properties file to permit this installation method.

This change will also provide better metadata for the library's Library Manager entry.

This change would also be [necessary ](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ)in order to submit the library for inclusion in the Library Manager index.

Fixes https://github.com/yutter/ArduinoJWT/issues/2

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format