### PR TITLE
Contenido invariable en la constante jwtHeader

### DIFF
--- a/src/ArduinoJWT.cpp
+++ b/src/ArduinoJWT.cpp
@@ -34,7 +34,7 @@
 #include "sha256.h"
 
 // The standard JWT header already base64 encoded. Equates to {"alg": "HS256", "typ": "JWT"}
-const PROGMEM char* jwtHeader = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+const PROGMEM char* const jwtHeader = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
 
 ArduinoJWT::ArduinoJWT(String psk) {
   _psk = psk;


### PR DESCRIPTION
El compilador necesita que una variable decorada con PROGMEM tenga su contenido marcado con 'const'.